### PR TITLE
Removed extra NuGet badge with broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 #Tyche
 ![Project logo - a Cornucopia](colored-cornucopia.png)
 
-[![Join the chat at https://gitter.im/TycheOrg/Tyche](https://badges.gitter.im/TycheOrg/Tyche.svg)](https://gitter.im/TycheOrg/Tyche?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)  [![NuGet](https://img.shields.io/nuget/dt/Tyche.svg)](https://www.nuget.org/packages/Tyche/)  [![NuGet](https://img.shields.io/nuget/v/Tyche.svg)](https://www.nuget.org/packages/Tyche/)
+[![Join the chat at https://gitter.im/TycheOrg/Tyche](https://badges.gitter.im/TycheOrg/Tyche.svg)](https://gitter.im/TycheOrg/Tyche?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)  [![NuGet](https://img.shields.io/nuget/v/Tyche.svg)](https://www.nuget.org/packages/Tyche/)
 
 [Tyche](https://en.wikipedia.org/wiki/Tyche) was the Greek god of fortune. (In Rome she is know as Fortuna). Her symbol was the Cornucopia, hence the logo
 


### PR DESCRIPTION
README.md had a duplicate NuGet badge with a broken image link, as shown in the image:
![img_8720](https://cloud.githubusercontent.com/assets/11466676/20487725/9004365e-b02a-11e6-80c4-bc8eb91c27ce.PNG)
I've fixed it by removing the broken badge in the middle.